### PR TITLE
Threaded behaviour for gps and problemPicture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /captures
 build.gradle
 gradle.properties
+gradle.properties

--- a/app/src/main/java/doge/watchdoge/imagehandlers/GpsPictureCreationThread.java
+++ b/app/src/main/java/doge/watchdoge/imagehandlers/GpsPictureCreationThread.java
@@ -1,0 +1,59 @@
+package doge.watchdoge.imagehandlers;
+
+import android.graphics.Bitmap;
+import android.location.Location;
+import android.net.Uri;
+import android.support.v4.util.Pair;
+
+import java.io.File;
+
+import doge.watchdoge.activities.MainActivity;
+import doge.watchdoge.creategpspicture.createGPSPicture;
+
+import static doge.watchdoge.activities.MainActivity.updateUrisHashmap;
+
+/**
+ * Created by Frey on 20.11.2016.
+ */
+
+public class GpsPictureCreationThread extends Thread {
+
+
+    private boolean mRequestingLocationUpdates;
+    private Pair<Double, Double> gpscoordinates;
+    private Location mLastLocation;
+
+    public GpsPictureCreationThread(boolean mRequestingLocationUpdates, Pair<Double, Double> gpscoordinates, Location mLastLocation) {
+        this.mRequestingLocationUpdates = mRequestingLocationUpdates;
+        this.gpscoordinates = gpscoordinates;
+        this.mLastLocation = mLastLocation;
+
+    }
+
+    public void run() {
+        try {
+            Bitmap tmp;
+            if (!mRequestingLocationUpdates) {
+                tmp = createGPSPicture.CreateGPSPicture(gpscoordinates);
+            } else {
+                tmp = createGPSPicture.CreateGPSPicture(null);
+            }
+
+            //ImageView img = (ImageView) findViewById(R.id.imageView);
+            //img.setImageBitmap(tmp);
+            String newGpsPictureName = MainActivity.gpspicbasename;
+            if (mLastLocation != null) {
+                //int accuracy = (int)mLastLocation.getAccuracy();
+                float accuracy = mLastLocation.getAccuracy();
+                newGpsPictureName += "_" + accuracy + "m";
+            } else newGpsPictureName += "_m";
+
+            Uri newName = ImageHandlers.bitmapToPNG(tmp, newGpsPictureName);
+            if (newName != null)
+                updateUrisHashmap(MainActivity.gpspicbasename, newName);
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.out.println("Creating GPS Picture failed.");
+        }
+    }
+}

--- a/app/src/main/java/doge/watchdoge/imagehandlers/PictureCreationThread.java
+++ b/app/src/main/java/doge/watchdoge/imagehandlers/PictureCreationThread.java
@@ -1,0 +1,42 @@
+package doge.watchdoge.imagehandlers;
+
+import android.net.Uri;
+
+import java.io.File;
+
+import doge.watchdoge.activities.MainActivity;
+
+
+/**
+ * Created by Frey on 20.11.2016.
+ */
+
+/**
+ * Thread that creates bitmap and uri from the camera picture
+ */
+public class PictureCreationThread extends Thread {
+    Object[] DataTransfer;
+    Uri probPicUri;
+
+    public PictureCreationThread(Object[] data, Uri probPicUri) {
+        DataTransfer = data;
+        this.probPicUri = probPicUri;
+    }
+
+    public void run() {
+        File file = (File)DataTransfer[0];
+        //debug time taken creating picture
+        long startTime = System.currentTimeMillis();
+        probPicUri = ImageHandlers.decodeSampledBitmapFromFile(file.getAbsolutePath(), (String)DataTransfer[1], 1920, 1080);
+
+        //debug time taken creating picture
+        long difference = System.currentTimeMillis() - startTime;
+        System.out.println(difference + " milliseconds to make picture");
+
+        if (probPicUri != null)
+            MainActivity.updateUrisHashmap((String)DataTransfer[1], probPicUri);
+        }
+}
+
+
+


### PR DESCRIPTION
application responds much faster when returning from camera.

AsyncTask tested on problempicture but slowed down the main thread, see commit [https://github.com/WatchDoges/WatchDoge/commit/991b324343e909675d1129ecf2cfdba77d0a34b1](url) 

Async task still used when creating gpsPicture, and it's assigned a separate thread.

gradle.properties commit could not be reverted...